### PR TITLE
Ignoring negative timestamp in UpdateTimings

### DIFF
--- a/Lib/Windows/MotionFlow/MotionSource.cs
+++ b/Lib/Windows/MotionFlow/MotionSource.cs
@@ -158,7 +158,9 @@ namespace Lada.Windows.MotionFlow
             // for information on timestamp seee http://msdn.microsoft.com/en-us/library/ms644939(VS.85).aspx
 
             if (timeStamp < 0)
-                throw new ArgumentOutOfRangeException ("timeStamp");
+            {
+                timeStamp = 0;
+            }
 
             if (_timeStamp >= 0)
             {


### PR DESCRIPTION
Why should negative timestamps be a problem? We see unnecessary exceptions on our systems which are gone with this fix without breaking the usual functionality of the library (at least the part we're using).